### PR TITLE
测试代码

### DIFF
--- a/src/components/zxbReportApply.vue
+++ b/src/components/zxbReportApply.vue
@@ -29,8 +29,12 @@
                         <el-input v-model="haveCreditCode.reportbuyerNo"></el-input>
                     </td>
                     <td style="background:#FAFAFA"></td>
-                    <td style="background:#FAFAFA"></td>
-                    <td style="background:#FAFAFA"></td>
+                  <td>
+                    <el-input v-model="haveCreditCode.reportCorpChnName"></el-input>
+                  </td>
+                  <td>
+                    <el-input v-model="haveCreditCode.reportCorpEngName"></el-input>
+                  </td>
                     <td style="background:#FAFAFA"></td>
                     <td style="background:#FAFAFA"></td>
                     <td>
@@ -212,6 +216,9 @@
                 } else if (!this.haveCreditCode.reportbuyerNo || this.haveCreditCode.reportbuyerNo == '') {
                     this.$message.warning('请输入待调查企业中国信保企业代码');
                     return;
+                }else if (this.haveCreditCode.reportCorpChnName === '' && this.haveCreditCode.reportCorpEngName === '') {
+                  this.$message.warning('请输入待调查企业中文名称或英文名称');
+                  return;
                 }
                 this.$ajax.manage.zhongxinbaoApply(this.haveCreditCode).then(res => {
                     if (res.status == 200) {

--- a/src/views/HomeLogin.vue
+++ b/src/views/HomeLogin.vue
@@ -13,11 +13,12 @@
         <div><img src="../../public/img/subtitle.png" alt=""></div>
       </div>
       <div class="content">
-        <el-input placeholder="请输入内容" v-model="searchVal" class="search-input" style="width: 840px;height: 76px;"
+        <el-input placeholder="请输入内容" v-model="searchVal" class="search-input" style="width: 600px;height:60px;"
           clearable="" @keyup.enter.native="seachContent">
         </el-input>
         <el-button @click="seachContent">查 询
         </el-button>
+        <el-button @click="blarSearch">全网搜索</el-button>
       </div>
     </div>
 
@@ -173,22 +174,22 @@ export default {
     .content {
       /deep/.el-button {
         border-radius: 0;
-        height: 76px;
-        width: 143px;
+        height: 60px;
+        width: 121px;
         background: #409eff;
         color: #fff;
-        border-top-right-radius: 38px;
-        border-bottom-right-radius: 38px;
+        //border-top-right-radius: 38px;
+        //border-bottom-right-radius: 38px;
         border: none;
         font-size: 20px;
         font-weight: bold;
       }
       /deep/.el-input__inner {
-        height: 76px;
+        height: 60px;
         line-height: 76px;
         font-size: 16px;
-        border-top-left-radius: 38px;
-        border-bottom-left-radius: 38px;
+        //border-top-left-radius: 38px;
+        //border-bottom-left-radius: 38px;
         padding: 0 30px;
         font-size: 20px;
         border: 1px solid #00f1fe;

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -34,10 +34,11 @@
         <div><img src="../../public/img/subtitle.png" alt=""></div>
       </div>
       <div class="content">
-        <el-input @keyup.enter="seachContent" placeholder="请输入内容" v-model="searchVal" class="search-input" style="width: 840px;height: 76px;"
+        <el-input @keyup.enter="seachContent" placeholder="请输入内容" v-model="searchVal" class="search-input" style="width: 600px;height: 60px;"
           clearable="" @keyup.enter.native="seachContent">
         </el-input>
-        <el-button @click="seachContent">查 询</el-button>
+        <el-button @click="seachContent">站内搜索</el-button>
+        <el-button @click="blarSearch">全网搜索</el-button>
       </div>
       <div class="latest-search">
         最近搜索：
@@ -80,7 +81,7 @@
             <span class="text">
               根据关键字，共搜索到 {{searchList.length>0?searchList.length:0}} 条数据结果，结果来自
               {{sourceType}}
-              <a class="postLink" @click="blarSearch">模糊接口查询</a>
+<!--              <a class="postLink" @click="blarSearch">模糊接口查询</a>-->
             </span>
           </div>
           <div class="main">
@@ -563,22 +564,22 @@ export default {
     .content {
       /deep/.el-button {
         border-radius: 0;
-        height: 76px;
-        width: 143px;
+        height: 60px;
+        width: 121px;
         background: #409eff;
         color: #fff;
-        border-top-right-radius: 38px;
-        border-bottom-right-radius: 38px;
+        //border-top-right-radius: 38px;
+        //border-bottom-right-radius: 38px;
         border: none;
         font-size: 20px;
         font-weight: bold;
       }
       /deep/.el-input__inner {
-        height: 76px;
+        height: 60px;
         line-height: 76px;
         font-size: 16px;
-        border-top-left-radius: 38px;
-        border-bottom-left-radius: 38px;
+        //border-top-left-radius: 38px;
+        //border-bottom-left-radius: 38px;
         padding: 0 30px;
         font-size: 20px;
         border: 1px solid #00f1fe;

--- a/src/views/ZxbApplyList.vue
+++ b/src/views/ZxbApplyList.vue
@@ -3,13 +3,27 @@
         <div style="margin-bottom: 15px;">
             <el-breadcrumb separator-class="el-icon-arrow-right">
                 <el-breadcrumb-item :to="{ path: '/homePage' }">首页</el-breadcrumb-item>
-                <el-breadcrumb-item>信保报告列表</el-breadcrumb-item>
+                <el-breadcrumb-item>信保报告审核</el-breadcrumb-item>
             </el-breadcrumb>
         </div>
         <div class="searchbox">
             <el-input class="fl-left manageTableInput" v-model="search.xcode" placeholder="请输入信保代码" clearable
                       style="width: 200px;margin-right: 10px;">
             </el-input>
+            <el-input class="fl-left manageTableInput" v-model="search.companyName" placeholder="请输入中/英文名称" clearable
+                      style="width: 200px;margin-right: 10px;">
+            </el-input>
+<!--           @change="changeApprove(approve)"-->
+          <el-select style="margin: 0 10px" v-model="search.approve" placeholder="请选择审批标识" size="medium">
+            <el-option v-for="item in approves" :key="item" :label="item" :value="item">
+            </el-option>
+          </el-select>
+          <el-input class="fl-left manageTableInput" v-model="search.informant" placeholder="请输入填报人" clearable
+                    style="width: 200px;margin-right: 10px;">
+          </el-input>
+          <el-input class="fl-left manageTableInput" v-model="search.approver" placeholder="请输入审批人" clearable
+                    style="width: 200px;margin-right: 10px;">
+          </el-input>
             <el-button type="primary" icon="el-icon-search" @click="searchData">查询</el-button>
         </div>
         <div class="table-box">
@@ -25,10 +39,13 @@
                 </el-table-column>
                 <el-table-column prop="reportCorpCountryCode" show-overflow-tooltip label="国别">
                 </el-table-column>
-                <el-table-column prop="reportCorpChnName" show-overflow-tooltip label="中文名称">
+                <el-table-column prop="reportCorpChnName,reportCorpEngName" show-overflow-tooltip label="中英文名称">
+                    <template slot-scope="scope">
+                        {{scope.row.reportCorpChnName}}/{{scope.row.reportCorpEngName}}
+                    </template>
                 </el-table-column>
-                <el-table-column prop="reportCorpEngName" show-overflow-tooltip label="英文名称">
-                </el-table-column>
+<!--                <el-table-column prop="reportCorpEngName" show-overflow-tooltip label="英文名称">-->
+<!--                </el-table-column>-->
                 <el-table-column prop="creditno" show-overflow-tooltip label="统一社会信用代码">
                 </el-table-column>
                 <el-table-column prop="istranslation" show-overflow-tooltip label="是否导读">
@@ -93,7 +110,10 @@
             return{
                 search:{
                     xcode:'',
-                    name:''
+                    companyName:'',
+                    approve:'待审核',
+                    informant:'',
+                    approver:''
                 },
                 loading: false,
                 page:{
@@ -110,7 +130,8 @@
                 pdfProgressVisible: true,
                 progressNum: 0,
                 startTimer: '',
-                endTimer: ''
+                endTimer: '',
+                approves:['通过', '不通过', '待审核','异常'],
             }
         },
         mounted () {
@@ -122,6 +143,10 @@
                     pageIndex: page ? page : 1,
                     pageSize: this.page.pageSize,
                     zxbCode:this.search.xcode,
+                    zxbCompanyName:this.search.companyName,
+                    zxbApprove:this.search.approve,
+                    zxbInformant:this.search.informant,
+                    zxbApprover:this.search.approver,
                     operator: this.$Cookies.get('userCode')
                 }
                 this.loading = true;
@@ -167,7 +192,8 @@
                     return ''
                 };
                 return moment(date).format("YYYY-MM-DD HH:mm:ss")
-            }
+            },
+
         }
     }
 </script>

--- a/src/views/report/AreaCreditEvaluate.vue
+++ b/src/views/report/AreaCreditEvaluate.vue
@@ -301,7 +301,14 @@ export default {
       this.$ajax.manage.getRegionRatingHtml(param).then(res => {
         console.log(res);
         if (res.status == 200) {
-          this.htmlContent = res.data;
+          //this.htmlContent = res.data;
+          if(res.data.code&&res.data.code!='0'){
+            this.htmlContent=JSON.stringify(res.data)
+          }else{
+            if(res.data.toString().lastIndexOf("{\"code\":\"0\"}")){
+              this.htmlContent =  res.data.toString().replace("{\"code\":\"0\"}","");
+            }
+          }
           let temp = 'content-disposition'
           let data = res.headers[temp];
           this.fileName = data.split('=')[1];

--- a/src/views/report/CityInvEvaluate.vue
+++ b/src/views/report/CityInvEvaluate.vue
@@ -305,7 +305,13 @@ export default {
       this.$ajax.manage.getCityInvRatingHtml(param).then(res => {
         console.log(res);
         if (res.status == 200) {
-          this.htmlContent = res.data;
+          if(res.data.code&&res.data.code!='0'){
+            this.htmlContent=JSON.stringify(res.data)
+          }else{
+            if(res.data.toString().lastIndexOf("{\"code\":\"0\"}")){
+              this.htmlContent =  res.data.toString().replace("{\"code\":\"0\"}","");
+            }
+          }
           let temp = 'content-disposition'
           let data = res.headers[temp];
           this.fileName = data.split('=')[1];

--- a/src/views/report/CreditEvaluate.vue
+++ b/src/views/report/CreditEvaluate.vue
@@ -210,10 +210,17 @@ export default {
       this.$ajax.manage.getHtml(param).then(res => {
         console.log(res);
         if (res.status == 200) {
+          // if(res.data.code&&res.data.code!='0'){
+          //   this.htmlContent=JSON.stringify(res.data)
+          // }else{
+          //   this.htmlContent = res.data;
+          // }
           if(res.data.code&&res.data.code!='0'){
             this.htmlContent=JSON.stringify(res.data)
           }else{
-            this.htmlContent = res.data;
+            if(res.data.toString().lastIndexOf("{\"code\":\"0\"}")){
+              this.htmlContent =  res.data.toString().replace("{\"code\":\"0\"}","");
+            }
           }
           //document.getElementById("html").innerHTML=res.data\
           let temp = 'content-disposition'

--- a/src/views/report/FinancialDemining.vue
+++ b/src/views/report/FinancialDemining.vue
@@ -261,7 +261,7 @@
 			    companyId: this.$route.query.companyId.toString(),
 			    creditCode: this.$route.query.creditCode,
 			    industry: this.professionDetail,
-				nature:this.companyType,
+				  nature:this.companyType,
 			    userId: this.$Cookies.get("userId"),
 			  }
 			  console.log(param)
@@ -271,9 +271,10 @@
 					if(res.data.code&&res.data.code!='0'){
 						this.htmlContent=JSON.stringify(res.data)
 					}else{
-						this.htmlContent = res.data;
+            if(res.data.toString().lastIndexOf("{\"code\":\"0\"}")){
+              this.htmlContent =  res.data.toString().replace("{\"code\":\"0\"}","");
+            }
 					}
-				  //this.htmlContent = res.data;
 				  let temp = 'content-disposition'
 				  let data = res.headers[temp];
 				  this.fileName = data.split('=')[1];

--- a/src/views/report/RiskScreen.vue
+++ b/src/views/report/RiskScreen.vue
@@ -78,7 +78,13 @@ export default {
       this.$ajax.manage.getRiskScreenHtml(param).then(res => {
         this.htmlLoading = false;
         if (res.status == 200) {
-          this.htmlContent = res.data;
+          if(res.data.code&&res.data.code!='0'){
+            this.htmlContent=JSON.stringify(res.data)
+          }else{
+            if(res.data.toString().lastIndexOf("{\"code\":\"0\"}")){
+              this.htmlContent =  res.data.toString().replace("{\"code\":\"0\"}","");
+            }
+          }
           let temp = 'content-disposition'
           let data = res.headers[temp];
           this.fileName = data.split('=')[1];

--- a/src/views/zxbReportList.vue
+++ b/src/views/zxbReportList.vue
@@ -95,7 +95,7 @@
                 let param = {
                     pageIndex: page ? page : 1,
                     pageSize: this.page.pageSize,
-                    name: this.search.name,
+                     companyName: this.search.name,
                     xcode: this.search.xcode,
                 }
                 this.loading = true;
@@ -107,6 +107,7 @@
                         this.page.total = res.data.totalRecords
                     }else{
                         this.$message.error(res.data.msg)
+                        console.log(res.data.msg)
                     }
                 }).catch(error=>{
                     console.log(error);
@@ -125,6 +126,7 @@
                 //pdf下载
                 let param = {
                     "noticeSerialno": pdfName,
+                    "isDownload":"1"
                 }
                 this.$ajax.manage.getPDF(param).then(res => {
                     console.log(res)
@@ -149,7 +151,8 @@
             viewPdf (pdfName) {
                 let src = '';
                 let param = {
-                    "noticeSerialno": pdfName
+                    "noticeSerialno": pdfName,
+                    "isDownload":"0"
                 }
                 this.pdfDialogVisible = true;
                 this.pdfProgressVisible = true;


### PR DESCRIPTION
信保报告列表对于查询为空的结果统一下，显示暂无数据，信保报告申请，有信保代码时名称也做必填项，门户搜索按钮分成两个，站内搜索和全网搜索，站内搜索搜索主档库，全网搜索调用模糊查询接口，信保报告列表筛选条件增加，审核页面内容精炼（添加系多个搜索框，合并中英文）